### PR TITLE
Update GameServer.cs

### DIFF
--- a/src/Network/GameServer.cs
+++ b/src/Network/GameServer.cs
@@ -87,9 +87,9 @@ namespace NetBoxes.Network
             Debug.WriteLine(disconnectInfo.Reason.ToString() + " from {0}!", peer.EndPoint);
             _players.Remove(peer.Id);
 
-            var players = Context.GameState.Players;
-            var players2 = (from li in players where li.PeerId == peer.Id select li).FirstOrDefault();
-            players.Remove(players2);
+            var playersList = Context.GameState.Players;
+            var disconnectedPlayer = (from li in playersList where li.PeerId == peer.Id select li).FirstOrDefault();
+            playersList.Remove(disconnectedPlayer);
 
         }
 

--- a/src/Network/GameServer.cs
+++ b/src/Network/GameServer.cs
@@ -40,6 +40,7 @@ namespace NetBoxes.Network
 
             _listener.ConnectionRequestEvent += OnConnectionRequest;
             _listener.PeerConnectedEvent += OnPeerConnected;
+            _listener.PeerDisconnectedEvent += OnPeerDisconnected;
 
             _listener.NetworkReceiveEvent += OnNetworkReceive;
 
@@ -80,6 +81,16 @@ namespace NetBoxes.Network
                 PlayerStatePacket statePacket = PlayerStatePacket.FromPlayerState(pair.Key, pair.Value);
                 peer.Send(_packetProcessor.Write(statePacket), DeliveryMethod.ReliableOrdered);
             }
+        }
+        
+        private void OnPeerDisconnected(NetPeer peer, DisconnectInfo disconnectInfo) {
+            Debug.WriteLine(disconnectInfo.Reason.ToString() + " from {0}!", peer.EndPoint);
+            _players.Remove(peer.Id);
+
+            var players = Context.GameState.Players;
+            var players2 = (from li in players where li.PeerId == peer.Id select li).FirstOrDefault();
+            players.Remove(players2);
+
         }
 
         private void OnPlayerInputPacketReceive(PlayerInputPacket inputPacket, NetPeer peer)


### PR DESCRIPTION
Added a on disconnect so that your server doesn't crash on someone trying to rejoin using a peer.Id that already exists and posts a reason for the disconnect in the console.

Basically what I wrote removes the peer.Id and then removes the player from the list so it gets removed from the players being drawn on disconnect.